### PR TITLE
add `dev` command to package.json's scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "postinstall": "npm audit fix",
         "prestart": "npm run build",
         "dbs": "docker run -it --rm -p27017:27017 mongo",
+        "dev": "ts-node src/index.ts",
         "start": "node out/index.js",
         "clean": "rm -rf ./out || true",
         "prebuild": "npm run clean",


### PR DESCRIPTION
Add a scripts entry point called "dev" that starts the bot locally using tsnode from the local dependencies.